### PR TITLE
Fix running as a runnable JAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ to submit proposals for a fake conference. Other users can vote for proposals.
 The session planner of the conference can plan sessions in rooms for tracks.
 
 ## Quickstart
-TODO: Describe how to compile the code and configure
-the necessary settings to get the application working.
+A simple `mvn clean package` should do the trick. 
+After that, start the app using `java -Dspring.datasource.password=MyAwesomePassword -jar target/proposalkeeper-1.0-SNAPSHOT.jar`

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,3 @@
+spring:
+  thymeleaf:
+    prefix: classpath:/templates

--- a/src/main/resources/templates/account/login.html
+++ b/src/main/resources/templates/account/login.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 
 <html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      xmlns:th="http://www.thymeleaf.org" layout:decorate="~{layouts/master}"
+      xmlns:th="http://www.thymeleaf.org" layout:decorate="~{/layouts/master}"
       xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity4">
 <head>
   <title>Sign in - Proposalkeeper</title>

--- a/src/main/resources/templates/account/register.html
+++ b/src/main/resources/templates/account/register.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 
 <html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      xmlns:th="http://www.thymeleaf.org" layout:decorate="~{layouts/master}"
+      xmlns:th="http://www.thymeleaf.org" layout:decorate="~{/layouts/master}"
       xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity4">
 <head>
   <title>Register- Proposalkeeper</title>

--- a/src/main/resources/templates/proposals/index.html
+++ b/src/main/resources/templates/proposals/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 
 <html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      xmlns:th="http://www.thymeleaf.org" layout:decorate="~{layouts/master}"
+      xmlns:th="http://www.thymeleaf.org" layout:decorate="~{/layouts/master}"
       xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity4">
 <head>
   <title>Proposals - Proposalkeeper</title>

--- a/src/main/resources/templates/proposals/new.html
+++ b/src/main/resources/templates/proposals/new.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 
 <html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      xmlns:th="http://www.thymeleaf.org" layout:decorate="~{layouts/master}"
+      xmlns:th="http://www.thymeleaf.org" layout:decorate="~{/layouts/master}"
       xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity4">
 <head>
   <title>Submit new proposal - Proposalkeeper</title>

--- a/src/main/resources/templates/proposals/submitted.html
+++ b/src/main/resources/templates/proposals/submitted.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 
 <html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      xmlns:th="http://www.thymeleaf.org" layout:decorate="~{layouts/master}"
+      xmlns:th="http://www.thymeleaf.org" layout:decorate="~{/layouts/master}"
       xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity4">
 <head>
   <title>Proposals - Proposalkeeper</title>


### PR DESCRIPTION
See https://github.com/spring-projects/spring-boot/issues/1744. Thymeleaf templates preceded by a slash are found when running in an IDE but not when running from a jar.

Solution taken from http://stackoverflow.com/a/27282606/1523342. In a nutshell: if a resouce path contains `//`, things go awry.